### PR TITLE
Add ability to decrease verbosity in mongos extended query statistics

### DIFF
--- a/src/mongo/s/commands/_joom_diagnostics.cpp
+++ b/src/mongo/s/commands/_joom_diagnostics.cpp
@@ -31,7 +31,9 @@ public:
              const std::string& dbname,
              const BSONObj& cmdObj,
              BSONObjBuilder& result) override {
-        JoomTop::get(opCtx->getServiceContext()).append(result);
+        bool verbose = cmdObj["verbose"].booleanSafe();
+        JoomTop::get(opCtx->getServiceContext()).append(result, verbose);
+
         return true;
     }
 

--- a/src/mongo/s/stats/joom_latency_histogram.cpp
+++ b/src/mongo/s/stats/joom_latency_histogram.cpp
@@ -7,6 +7,7 @@
 
 namespace mongo {
 
+// latency measured in microseconds(src/mongo/s/stats/joom_top.cpp)
 const std::vector<uint64_t> JoomLatencyHistogram::kUpperBoundsMicros = exponentialBucketsWithExpectedMedian(1000, 10000, 60000000, kMaxBuckets);
 
 void JoomLatencyHistogram::increment(CommandName cmdName, uint64_t latency, bool isError, bool isUser) {

--- a/src/mongo/s/stats/joom_latency_histogram.cpp
+++ b/src/mongo/s/stats/joom_latency_histogram.cpp
@@ -7,19 +7,7 @@
 
 namespace mongo {
 
-const std::array<uint64_t, JoomLatencyHistogram::kMaxBuckets>
-    JoomLatencyHistogram::kUpperBoundsMicros = {
-        1000,
-        5000,
-        10000,
-        20000,
-        50000,
-        100000,
-        300000,
-        500000,
-        1000000,
-        3000000,
-    };
+const std::vector<uint64_t> JoomLatencyHistogram::kUpperBoundsMicros = exponentialBucketsWithExpectedMedian(1000, 10000, 60000000, kMaxBuckets);
 
 void JoomLatencyHistogram::increment(CommandName cmdName, uint64_t latency, bool isError, bool isUser) {
     switch (cmdName) {
@@ -49,7 +37,34 @@ void JoomLatencyHistogram::increment(CommandName cmdName, uint64_t latency, bool
     }
 }
 
+void JoomLatencyHistogram::add(const JoomLatencyHistogram* data) {
+    this->_insert._add(&data->_insert);
+    this->_find._add(&data->_find);
+    this->_findAndModify._add(&data->_findAndModify);
+    this->_update._add(&data->_update);
+    this->_delete._add(&data->_delete);
+    this->_aggregate._add(&data->_aggregate);
+    this->_distinct._add(&data->_distinct);
+    this->_other._add(&data->_other);
+}
+
 void JoomLatencyHistogram::append(BSONObjBuilder* builder) const {
+    HistogramData _read, _write;
+    _read._add(&_find);
+    _read._add(&_aggregate);
+    _read._add(&_distinct);
+    _append(&_read, "read", builder);
+
+    _write._add(&_insert);
+    _write._add(&_findAndModify);
+    _write._add(&_update);
+    _write._add(&_delete);
+    _append(&_write, "write", builder);
+
+    _append(&_other, "other", builder);
+}
+
+void JoomLatencyHistogram::appendVerbose(BSONObjBuilder* builder) const {
     _append(&_insert, "insert", builder);
     _append(&_find, "find", builder);
     _append(&_findAndModify, "findAndModify", builder);

--- a/src/mongo/s/stats/joom_latency_histogram.h
+++ b/src/mongo/s/stats/joom_latency_histogram.h
@@ -32,10 +32,12 @@ const static StringMap<CommandName> StringToCommandNameMap = {
 const static std::vector<uint64_t> exponentialBuckets(uint64_t min, uint64_t max, size_t count) {
     std::vector<uint64_t> buckets;
     buckets.reserve(count);
-    double step = std::exp(std::log(max/min) / static_cast<double>(count - 1));
+    double step = std::exp(std::log(static_cast<double>(max)/static_cast<double>(min)) / static_cast<double>(count - 1));
 
-    uint64_t value = min;
+    double value = min;
     for (size_t i = 0; i < count - 1; ++i) {
+        // losing precision here is OK, because we measure latency in microseconds
+        // and fraction of microsecond doesn't make sense for us in any case.
         buckets.push_back(std::round(value));
         value *= step;
     }
@@ -79,7 +81,7 @@ private:
             this->sum += data->sum;
             this->successCount += data->successCount;
             this->errorCount += data->errorCount;
-            this->nonUserCount += nonUserCount;
+            this->nonUserCount += data->nonUserCount;
         }
     };
 

--- a/src/mongo/s/stats/joom_latency_histogram.h
+++ b/src/mongo/s/stats/joom_latency_histogram.h
@@ -29,12 +29,40 @@ const static StringMap<CommandName> StringToCommandNameMap = {
     {"distinct", CommandName::Distinct},
 };
 
+const static std::vector<uint64_t> exponentialBuckets(uint64_t min, uint64_t max, size_t count) {
+    std::vector<uint64_t> buckets;
+    buckets.reserve(count);
+    double step = std::exp(std::log(max/min) / static_cast<double>(count - 1));
+
+    uint64_t value = min;
+    for (size_t i = 0; i < count - 1; ++i) {
+        buckets.push_back(std::round(value));
+        value *= step;
+    }
+    buckets.push_back(max);
+
+    return buckets;
+}
+
+const static std::vector<uint64_t> exponentialBucketsWithExpectedMedian(uint64_t min, uint64_t median, uint64_t max, size_t count) {
+    size_t upperCount = count / 2;
+    size_t lowerCount = count - upperCount;
+
+    auto lowerBuckets = exponentialBuckets(min, median, lowerCount);
+    auto upperBuckets = exponentialBuckets(median, max, upperCount+1);
+    lowerBuckets.insert(lowerBuckets.end(), upperBuckets.begin() + 1, upperBuckets.end());
+
+    return lowerBuckets;
+}
+
 class JoomLatencyHistogram {
 public:
-    static const int kMaxBuckets = 10;
-    static const std::array<uint64_t, kMaxBuckets> kUpperBoundsMicros;
+    static const size_t kMaxBuckets = 16;
+    static const std::vector<uint64_t> kUpperBoundsMicros;
     void increment(CommandName cmdName, uint64_t latency, bool isError, bool isUser);
     void append(BSONObjBuilder* builder) const;
+    void appendVerbose(BSONObjBuilder* builder) const;
+    void add(const JoomLatencyHistogram* data);
 
 private:
     struct HistogramData {
@@ -43,6 +71,16 @@ private:
         uint64_t successCount = 0;
         uint64_t errorCount = 0;
         uint64_t nonUserCount = 0;
+
+        void _add(const HistogramData* data) {
+            for (size_t i = 0; i < kMaxBuckets; i++) {
+                this->buckets[i] += data->buckets[i];
+            }
+            this->sum += data->sum;
+            this->successCount += data->successCount;
+            this->errorCount += data->errorCount;
+            this->nonUserCount += nonUserCount;
+        }
     };
 
     static int _getBucket(uint64_t latency);

--- a/src/mongo/s/stats/joom_top.cpp
+++ b/src/mongo/s/stats/joom_top.cpp
@@ -137,7 +137,7 @@ StringMap<JoomLatencyHistogram> JoomTop::_compactUsageMap(const UsageMap& map) c
     StringMap<JoomLatencyHistogram> result;
     for (auto i = map.begin(); i != map.end(); ++i) {
         auto hashedDB = UsageMap::hasher().hashed_key(i->first);
-        auto stats = i->second;
+        auto &stats = i->second;
         for (auto j = stats.begin(); j != stats.end(); ++j) {
             result[hashedDB].add(&j->second);
         }

--- a/src/mongo/s/stats/joom_top.h
+++ b/src/mongo/s/stats/joom_top.h
@@ -21,15 +21,18 @@ public:
 
     JoomTop() = default;
 
-    typedef StringMap<JoomLatencyHistogram> UsageMap;
+    typedef StringMap<StringMap<JoomLatencyHistogram>> UsageMap;
 
 public:
     void record(OperationContext* opCtx, bool isError);
 
-    void append(BSONObjBuilder& b);
+    void append(BSONObjBuilder& b, bool verbose);
 
 private:
     void _appendToUsageMap(BSONObjBuilder& b, const UsageMap& map) const;
+    void _appendToUsageMapVerbose(BSONObjBuilder& b, const UsageMap& map) const;
+
+    StringMap<JoomLatencyHistogram> _compactUsageMap(const UsageMap& map) const;
 
     void _incrementHistogram(OperationContext* opCtx,
                              int64_t latency,


### PR DESCRIPTION
- Added `verbose` flag to `joomDiagnostics` cmd to control output format for simple per-database stats with operation type instead of per-db and per-collection stats with exact command histograms.
- Added dynamically created exponential-sized histograms.